### PR TITLE
Changed how the Accessory UUID is generated

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class TplinkLightbulbPlatform {
     platform.log('Lightbulb added: %s [%s]', name, light.deviceId)
 
     // 5 == Accessory.Categories.LIGHTBULB
-    const platformAccessory = new PlatformAccessory(name, UUIDGen.generate(light.deviceId), 5)
+    const platformAccessory = new PlatformAccessory(name, UUIDGen.generate(light.deviceId + light.name), 5)
 
     const lightService = platformAccessory.addService(Service.Lightbulb, name)
     lightService.addCharacteristic(Characteristic.Brightness)


### PR DESCRIPTION
If your network contains TP-Link smart plugs as well as smart bulbs, the bulbs show up as switches as well as bulbs on homebridge. The code currently generates the accessory UUID in the same way as the homebridge-hs100 project, so if you have both these plugins installed, homebridge crashes because it can't use the same UUID for two supposedly different accessories.

Some would say the solution is to use random, but this logic is simple - instead of using just the deviceId, We use a string combo of the deviceId and the name. I tested this on my local setup and it works well.